### PR TITLE
Fix to work with django 1.4 & 1.7

### DIFF
--- a/djorm_pguuid/fields.py
+++ b/djorm_pguuid/fields.py
@@ -48,6 +48,11 @@ class UUIDField(six.with_metaclass(SubfieldBase, Field)):
     def db_type(self, connection):
         return 'uuid'
 
+    def deconstruct(self):
+        name, path, args, kwargs = super(UUIDField, self).deconstruct()
+        kwargs["auto_add"] = self._auto_add
+        return name, path, args, kwargs
+
     def get_prep_value(self, value):
         if not value:
             if self.null or self._auto_add:


### PR DESCRIPTION
Fix for 1.4 is a simple import hack, for 1.7 I've given UUIDField a deconstruct method so it can be used in migrations smoothly.
